### PR TITLE
Update RandomForest_v4.ipynb

### DIFF
--- a/RandomForest_v4.ipynb
+++ b/RandomForest_v4.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#LOOCV function\n",
+    "#LOOCV function to run Random Forest\n",
     "def transcript_loocv(subject_names, classifier_name, clf, df_clean, featureset):\n",
     "    accuracy_fold = []\n",
     "    accuracy_fold1 = []\n",


### PR DESCRIPTION
Code works but the performance metrics are very low. I am still playing around with RF parameters. 

I am also getting the following warnings:
" FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result."
"Recall is ill-defined and being set to 0.0 in labels with no true samples." - same for Specificity, F-score, Precision