### PR TITLE
Add files via upload

### DIFF
--- a/RandomForest_v9.ipynb
+++ b/RandomForest_v9.ipynb
@@ -163,9 +163,7 @@
     "        #for every train-test split, obtain means only from training HC group (so that model is completely agnostic to labels)\n",
     "        X = df_data[featureset].values\n",
     "        y_label = df_data['group_label_id'].values\n",
-    "        years = df_data['age_at_record'].values\n",
-    "        years_diag = df_data['year_diag'].values\n",
-    "        sub_id = df_data['subject_id'].values\n",
+    "       
     "        X = StandardScaler().fit_transform(X)\n",
     "        sel = VarianceThreshold(threshold=(.99 * (1 - .99)))\n",
     "        X = sel.fit_transform(X)\n",

--- a/RandomForest_v9.ipynb
+++ b/RandomForest_v9.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#from collections import Counter\n",
+    "import warnings\n",
+    "warnings.filterwarnings("ignore")\n",
     "from scipy.stats import mode\n",
     "import statistics\n",
     "import pandas as pd\n",

--- a/RandomForest_v9.ipynb
+++ b/RandomForest_v9.ipynb
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "#append new dataframe with selected columns\n",
-    "clean_df = clean_df.join([df['subject_id'], df['firstname'], df['age_at_record'], df['year_diag'], df['group_label_id']])"
+    "clean_df = clean_df.join([df['firstname'], df['group_label_id']])"
    ]
   },
   {
@@ -158,12 +158,10 @@
     "        df_data = df_clean.copy()\n",
     "        df_data = df_data[df_data.firstname.isin(subject_names)]\n",
     "        ind_train = [~df_data['firstname'].isin([name])]\n",
-    "        ind_test = [df_data['firstname'].isin([name])]\n",
-    "        df_data = df_data.sort_values('age_at_record')\n",
+    "        ind_test = [df_data['firstname'].isin([name])]\n",    "        
     "        #for every train-test split, obtain means only from training HC group (so that model is completely agnostic to labels)\n",
     "        X = df_data[featureset].values\n",
-    "        y_label = df_data['group_label_id'].values\n",
-    "       
+    "        y_label = df_data['group_label_id'].values\n",       
     "        X = StandardScaler().fit_transform(X)\n",
     "        sel = VarianceThreshold(threshold=(.99 * (1 - .99)))\n",
     "        X = sel.fit_transform(X)\n",    " 
@@ -215,18 +213,12 @@
     "        df_data = df_data[df_data.firstname.isin(subject_names)]\n",
     "        ind_train = [~df_data['firstname'].isin([name])]\n",
     "        ind_test = [df_data['firstname'].isin([name])]\n",
-    "        df_data = df_data.sort_values('age_at_record')\n",
     "        #for every train-test split, obtain means only from training HC group (so that model is completely agnostic to labels)\n",
     "        X = df_data[featureset].values\n",
     "        y_label = df_data['group_label_id'].values\n",
-    "        years = df_data['age_at_record'].values\n",
-    "        years_diag = df_data['year_diag'].values\n",
-    "        sub_id = df_data['subject_id'].values\n",
     "        X = StandardScaler().fit_transform(X)\n",
     "        sel = VarianceThreshold(threshold=(.99 * (1 - .99)))\n",
-    "        X = sel.fit_transform(X)\n",
-    "        ind_train = [~df_data['firstname'].isin([name])]\n",
-    "        ind_test = [df_data['firstname'].isin([name])] \n",
+    "        X = sel.fit_transform(X)\n",         
     "        X_train = X[tuple(ind_train)]\n",
     "        X_test = X[tuple(ind_test)]\n",
     "        y_train = y_label[tuple(ind_train)]\n",

--- a/RandomForest_v9.ipynb
+++ b/RandomForest_v9.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#from collections import Counter\n",
+    "from scipy.stats import mode\n",
+    "import statistics\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import itertools\n",
+    "import statistics\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from imblearn.over_sampling import SMOTE\n",
+    "from imblearn.metrics import specificity_score\n",
+    "from sklearn.utils import shuffle\n",
+    "from sklearn.metrics import *\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.feature_selection import VarianceThreshold\n",
+    "from sklearn.ensemble import RandomForestClassifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('../wer_manASR_feat_v30.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#replace all +-inf with NaNs\n",
+    "df = df.replace([np.inf, -np.inf], np.nan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['diff_norm_pos_SPACE',\n",
+       " 'diff_norm_sub_coord_ratio',\n",
+       " 'diff_norm_tag_\"\"',\n",
+       " 'diff_norm_tag_#',\n",
+       " 'diff_norm_tag_$',\n",
+       " 'diff_norm_tag_-PRB-',\n",
+       " 'diff_norm_tag_BES',\n",
+       " 'diff_norm_tag_GW',\n",
+       " 'diff_norm_tag_HVS',\n",
+       " 'diff_norm_tag_SP']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#return list of columns that have only NaN values\n",
+    "df.columns[df.isnull().all()].tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#delete the NaNs columns\n",
+    "df.drop(['diff_norm_pos_SPACE','diff_norm_sub_coord_ratio','diff_norm_tag_\"\"', 'diff_norm_tag_#', 'diff_norm_tag_$', 'diff_norm_tag_-PRB-', 'diff_norm_tag_BES', 'diff_norm_tag_GW', 'diff_norm_tag_HVS', 'diff_norm_tag_SP'], axis=1, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#impute NaN for feature columns and store them in the new dataframe\n",
+    "imp = SimpleImputer(missing_values=np.nan, strategy='mean')\n",
+    "clean_df = pd.DataFrame(imp.fit_transform(df.loc[:, \"ADJP_->_JJ_x\":\"zcr_var_y\"]), columns = list(df)[df.columns.get_loc(\"ADJP_->_JJ_x\"):(df.columns.get_loc(\"zcr_var_y\") + 1)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#append new dataframe with selected columns\n",
+    "clean_df = clean_df.join([df['subject_id'], df['firstname'], df['age_at_record'], df['year_diag'], df['group_label_id']])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#get list of subject names\n",
+    "subj_names = df.iloc[:, -1].dropna().unique().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#select feature names\n",
+    "man_feat = list(df)[df.columns.get_loc(\"ADJP_->_JJ_x\"):(df.columns.get_loc(\"zcr_var_x\") + 1)]\n",
+    "asr_feat = list(df)[df.columns.get_loc(\"ADJP_->_JJ_y\"):(df.columns.get_loc(\"zcr_var_y\") + 1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#shuffle rows for better classification\n",
+    "clean_df = shuffle(clean_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#pick random forest for classifier\n",
+    "clf = RandomForestClassifier(n_estimators = 2, max_depth = 70)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#UPDATED - for SAMPLE - LOOCV function\n",
+    "def sample_transcript_loocv(subject_names, classifier_name, clf, df_clean, featureset):\n",
+    "    prediction = []\n",
+    "    y_test = []\n",
+    "    for name in subject_names:        \n",
+    "        df_data = df_clean.copy()\n",
+    "        df_data = df_data[df_data.firstname.isin(subject_names)]\n",
+    "        ind_train = [~df_data['firstname'].isin([name])]\n",
+    "        ind_test = [df_data['firstname'].isin([name])]\n",
+    "        df_data = df_data.sort_values('age_at_record')\n",
+    "        #for every train-test split, obtain means only from training HC group (so that model is completely agnostic to labels)\n",
+    "        X = df_data[featureset].values\n",
+    "        y_label = df_data['group_label_id'].values\n",
+    "        years = df_data['age_at_record'].values\n",
+    "        years_diag = df_data['year_diag'].values\n",
+    "        sub_id = df_data['subject_id'].values\n",
+    "        X = StandardScaler().fit_transform(X)\n",
+    "        sel = VarianceThreshold(threshold=(.99 * (1 - .99)))\n",
+    "        X = sel.fit_transform(X)\n",
+    "        ind_train = [~df_data['firstname'].isin([name])]\n",
+    "        ind_test = [df_data['firstname'].isin([name])] \n",
+    "        X_train = X[tuple(ind_train)]\n",
+    "        X_test = X[tuple(ind_test)]\n",
+    "        y_train = y_label[tuple(ind_train)]\n",
+    "        y_test.append(y_label[tuple(ind_test)])\n",
+    "        X_train,y_train = SMOTE(random_state=1,k_neighbors=3).fit_sample(X_train, y_train)     \n",
+    "        clf.fit(X_train,y_train)\n",
+    "        prediction.append(clf.predict(X_test))\n",
+    "        \n",
+    "    y_test = [item for sublist in y_test for item in sublist]\n",
+    "    prediction = [item for sublist in prediction for item in sublist]\n",
+    "    \n",
+    "    #don't need lists anymore since metrics return one value\n",
+    "    sensitivity = recall_score(y_pred = prediction, y_true = y_test, average='macro')\n",
+    "    specificity = specificity_score(y_true = y_test, y_pred = prediction, average='macro')\n",
+    "    precision = precision_score(y_pred = prediction, y_true = y_test, average='macro')\n",
+    "    f1 = f1_score(y_pred = prediction, y_true = y_test, average='macro')  \n",
+    "    accuracy = accuracy_score(y_true = y_test, y_pred = prediction)\n",
+    "        \n",
+    "    return accuracy,precision,sensitivity,f1,specificity #don't need mean since metrics return one value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#function to return a set of modes\n",
+    "def mode_set(array):\n",
+    "    most = max(list(map(array.count, array)))\n",
+    "    return list(set(filter(lambda x: array.count(x) == most, array)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#UPDATED - for SUBJECT - LOOCV function\n",
+    "def subject_transcript_loocv(subject_names, classifier_name, clf, df_clean, featureset):\n",
+    "    prediction_mode = []\n",
+    "    y_test_mode = []\n",
+    "    for name in subject_names:        \n",
+    "        df_data = df_clean.copy()\n",
+    "        df_data = df_data[df_data.firstname.isin(subject_names)]\n",
+    "        ind_train = [~df_data['firstname'].isin([name])]\n",
+    "        ind_test = [df_data['firstname'].isin([name])]\n",
+    "        df_data = df_data.sort_values('age_at_record')\n",
+    "        #for every train-test split, obtain means only from training HC group (so that model is completely agnostic to labels)\n",
+    "        X = df_data[featureset].values\n",
+    "        y_label = df_data['group_label_id'].values\n",
+    "        years = df_data['age_at_record'].values\n",
+    "        years_diag = df_data['year_diag'].values\n",
+    "        sub_id = df_data['subject_id'].values\n",
+    "        X = StandardScaler().fit_transform(X)\n",
+    "        sel = VarianceThreshold(threshold=(.99 * (1 - .99)))\n",
+    "        X = sel.fit_transform(X)\n",
+    "        ind_train = [~df_data['firstname'].isin([name])]\n",
+    "        ind_test = [df_data['firstname'].isin([name])] \n",
+    "        X_train = X[tuple(ind_train)]\n",
+    "        X_test = X[tuple(ind_test)]\n",
+    "        y_train = y_label[tuple(ind_train)]\n",
+    "        y_test = y_label[tuple(ind_test)].tolist() #don't need to append anymore, can just store as an array converted to list\n",
+    "        X_train,y_train = SMOTE(random_state=1,k_neighbors=3).fit_sample(X_train, y_train)     \n",
+    "        clf.fit(X_train,y_train)\n",
+    "        prediction = clf.predict(X_test).tolist() #don't need to append anymore, can just store as an array converted to list\n",
+    "        \n",
+    "        temp = mode_set(prediction)    #store results from mode for prediction in temp values to test if there are multiple modes returned\n",
+    "        y_test_mode.append(mode_set(y_test))\n",
+    "        if len(temp) == 2:\n",
+    "            y_test_mode.append(mode_set(y_test)) #store one more mode into y_test so that total numbers of modes is the same in test and prediction lists\n",
+    "            a, b = temp         #store the two modes as separate values\n",
+    "            pred_one = []\n",
+    "            pred_two = []\n",
+    "            pred_one.append(a)         #convert to list\n",
+    "            pred_two.append(b)\n",
+    "            prediction_mode.append(pred_one)       #add list value to predictions\n",
+    "            prediction_mode.append(pred_two)\n",
+    "        else:\n",
+    "            prediction_mode.append(temp)\n",
+    "    \n",
+    "    #don't need 'fold_...' lists anymore since metrics return only one value\n",
+    "    sensitivity = recall_score(y_pred = prediction_mode, y_true = y_test_mode, average='macro')\n",
+    "    specificity = specificity_score(y_true = y_test_mode, y_pred = prediction_mode, average='macro')\n",
+    "    precision = precision_score(y_pred = prediction_mode, y_true = y_test_mode, average='macro')\n",
+    "    f1 = f1_score(y_pred = prediction_mode, y_true = y_test_mode, average='macro')  \n",
+    "    accuracy = accuracy_score(y_true = y_test_mode, y_pred = prediction_mode)\n",
+    "        \n",
+    "    return accuracy,precision,sensitivity,f1,specificity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample performance [[0.43298097 0.40572959 0.4272924  0.39330853 0.4272924 ]]\n",
+      "Subject performance [[0.43333333 0.23161765 0.43333333 0.30174359 0.43333333]]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\python\\lib\\site-packages\\sklearn\\metrics\\classification.py:1143: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples.\n",
+      "  'precision', 'predicted', average, warn_for)\n",
+      "c:\\python\\lib\\site-packages\\sklearn\\metrics\\classification.py:1143: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no predicted samples.\n",
+      "  'precision', 'predicted', average, warn_for)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#run sample and subject LOOCV on manual transcript features\n",
+    "sample_manual_tr_performance = []\n",
+    "subject_manual_tr_performance = []\n",
+    "for i in range(5):\n",
+    "    sample_manual_tr_performance.append([sample_transcript_loocv(subj_names, 'random_forest', clf, clean_df, man_feat)])\n",
+    "    subject_manual_tr_performance.append([subject_transcript_loocv(subj_names, 'random_forest', clf, clean_df, man_feat)])\n",
+    "sample_avg_manual_tr_performance = np.mean(sample_manual_tr_performance, axis = 0)\n",
+    "subject_avg_manual_tr_performance = np.mean(subject_manual_tr_performance, axis = 0)\n",
+    "\n",
+    "print('Sample performance for manual transcripts', sample_avg_manual_tr_performance)\n",
+    "print('Subject performance for manual transcripts', subject_avg_manual_tr_performance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample performance for asr transcripts [[0.43298097 0.40572959 0.4272924  0.39330853 0.4272924 ]]\n",
+      "Subject performance for asr transcripts [[0.43333333 0.23161765 0.43333333 0.30174359 0.43333333]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#run sample and subject LOOCV on asr transcript features\n",
+    "sample_asr_tr_performance = []\n",
+    "subject_asr_tr_performance = []\n",
+    "for i in range(5):\n",
+    "    sample_asr_tr_performance.append([sample_transcript_loocv(subj_names, 'random_forest', clf, clean_df, asr_feat)])\n",
+    "    subject_asr_tr_performance.append([subject_transcript_loocv(subj_names, 'random_forest', clf, clean_df, asr_feat)])\n",
+    "sample_avg_asr_tr_performance = np.mean(sample_asr_tr_performance, axis = 0)\n",
+    "subject_avg_asr_tr_performance = np.mean(subject_asr_tr_performance, axis = 0)\n",
+    "\n",
+    "print('Sample performance for asr transcripts', sample_avg_manual_tr_performance)\n",
+    "print('Subject performance for asr transcripts', subject_avg_manual_tr_performance)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/RandomForest_v9.ipynb
+++ b/RandomForest_v9.ipynb
@@ -166,9 +166,7 @@
     "       
     "        X = StandardScaler().fit_transform(X)\n",
     "        sel = VarianceThreshold(threshold=(.99 * (1 - .99)))\n",
-    "        X = sel.fit_transform(X)\n",
-    "        ind_train = [~df_data['firstname'].isin([name])]\n",
-    "        ind_test = [df_data['firstname'].isin([name])] \n",
+    "        X = sel.fit_transform(X)\n",    " 
     "        X_train = X[tuple(ind_train)]\n",
     "        X_test = X[tuple(ind_test)]\n",
     "        y_train = y_label[tuple(ind_train)]\n",


### PR DESCRIPTION
Changes:
1. I broke down LOOCV into two functions: sample and subject
2. Edited LOOCV code for sample to remove the 'fold_...' lists and np.mean(fold_...) as they were no longer needed since the metrics calculated outside of the names loop on the final lists of prediction and tests and return one value
3. Wrote subject LOOCV - store modes for prediction and test for each subject within names loop. This results in two lists with length of 18 or more (in case multiple modes are returned). If multiple modes for prediction returned (both AD and HC) than additional test value is added to the test_mode list to match the length of prediction_mode list. Then outside of loop calculate the metrics based on these mode lists
4. Added a function that returns multiple modes
5. Re-wrote functions to calculate mean from 5 runs of both Sample and Subject LOOCV

Note: metrics for Subject LOOCV are of course lower and often some of them have the same values (e.g. [[0.43333333 0.23161765 0.43333333 0.30174359 0.43333333]])

Outstanding:
In Subject LOOCV I am still getting a warning about ill-defined metrics which blows my mind as they are calculated outside of the names loop and since there are healthy subjects in the study there are always both AD and HC labels in test_mode list. So, I don't know what causes this warning. Will try to figure it out